### PR TITLE
Build database across repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ find_sorries = "sorrydb.scripts.find_sorries:main"
 get_lean_repos = "sorrydb.scripts.get_lean_repos:main"
 get_mathlib_contributors = "sorrydb.scripts.get_mathlib_contributors:main"
 offline_sorries = "sorrydb.scripts.offline_sorries:main"
+build_sorry_db = "sorrydb.scripts.build_sorry_db:main"
 
 
 [build-system]

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -234,7 +234,7 @@ def get_repo_lean_version(repo_path: Path) -> str:
 
 
 
-def build_database(repo_url: str, branch: str | None = None, 
+def prepare_and_process_lean_repo(repo_url: str, branch: str | None = None, 
                   lean_data: Path | None = None, subdir: str | None = None):
     """
     Comprehensive function that prepares a repository, builds a Lean project, 

--- a/src/sorrydb/scripts/build_sorry_db.py
+++ b/src/sorrydb/scripts/build_sorry_db.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from sorrydb.database.build_database import build_database
+
+def main():
+    parser = argparse.ArgumentParser(description='Build a SorryDatabase from multiple Lean repositories.')
+    parser.add_argument('--repos-file', type=str, required=True,
+                       help='JSON file containing list of repositories to process')
+    parser.add_argument('--output', type=str, default='sorry_database.json',
+                       help='Output file path for the database (default: sorry_database.json)')
+    parser.add_argument('--lean-data-dir', type=str, default='lean_data',
+                       help='Directory for repository checkouts and Lean data (default: lean_data)')
+    # Add simple logging options
+    parser.add_argument('--log-level', type=str, default='INFO',
+                       choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+                       help='Set the logging level (default: INFO)')
+    parser.add_argument('--log-file', type=str,
+                       help='Log file path (default: output to stdout)')
+    
+    args = parser.parse_args()
+    
+    # Configure logging
+    log_kwargs = {
+        'level': getattr(logging, args.log_level),
+        'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    }
+    if args.log_file:
+        log_kwargs['filename'] = args.log_file
+    logging.basicConfig(**log_kwargs)
+    
+    logger = logging.getLogger(__name__)
+    
+    # Create lean data directory
+    lean_data = Path(args.lean_data_dir)
+    lean_data.mkdir(exist_ok=True)
+    
+    with open(args.repos_file, 'r') as f:
+        repos_data = json.load(f)
+
+    repos_list = repos_data["repos"]
+    
+    # Build the database
+    try:
+        logger.info(f"Building database from {len(repos_list)} repositories")
+        build_database(
+            repo_list=repos_list,
+            lean_data=lean_data,
+            output_path=args.output
+        )
+        
+    except Exception as e:
+        logger.error(f"Error building database: {e}")
+        logger.exception(e)
+        return 1
+    
+    return 0
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/sorrydb/scripts/offline_sorries.py
+++ b/src/sorrydb/scripts/offline_sorries.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import json
 import logging
 
-from sorrydb.database.build_database import build_database
+from sorrydb.database.build_database import prepare_and_process_lean_repo
 
 def main():
     parser = argparse.ArgumentParser(description='Process Lean files in a repository using lean-repl-py.')
@@ -38,7 +38,7 @@ def main():
     lean_data = Path(args.lean_data_dir)
     lean_data.mkdir(exist_ok=True)
     
-    results = build_database(
+    results = prepare_and_process_lean_repo(
         repo_url=args.repo_url,
         branch=args.branch,
         lean_data=lean_data,

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -1,19 +1,19 @@
-from sorrydb.database.build_database import build_database
+from sorrydb.database.build_database import prepare_and_process_lean_repo
 
 
-def test_build_database_with_mutiple_lean_versions():
+def test_prepare_and_process_lean_repo_with_mutiple_lean_versions():
     """
     Verify that the database builder can handle repositories
     that use different versions of Lean.
     
     sorryClientTestRepoMath uses v4.17.0-rc1 and sorryClientTestRepo uses v4.16.0
     """
-    mathRepoResults = build_database(
+    mathRepoResults = prepare_and_process_lean_repo(
         repo_url='https://github.com/austinletson/sorryClientTestRepoMath',
     )
 
     assert len(mathRepoResults["sorries"]) > 0
-    repoResults = build_database(
+    repoResults = prepare_and_process_lean_repo(
         repo_url='https://github.com/austinletson/sorryClientTestRepo',
     )
 


### PR DESCRIPTION
the `build_sorry_db` script calls the new `build_database` method which
loops through a list of repos in the format of `test_repos.json`
and creates a json database from all the sorries in the repo.

The database is a flat structure, i.e., each sorry record duplicates
the repo metadata.

`build_database` also generates a uuid for each sorry.

Note, the name of the build_sorry_db scripts is intentionally different
from the `build_database` method, but we may should align them.
@austinletson
