### PR TITLE
feat: use tempfile for lean_data dir by default

### DIFF
--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -3,7 +3,9 @@ import json
 from pathlib import Path
 import hashlib
 import logging
+from typing import Optional
 import uuid
+import tempfile
 from sorrydb.crawler.git_ops import get_git_blame_info, get_repo_metadata, prepare_repository
 from sorrydb.repro.repl_api import LeanRepl, get_goal_parent_type, setup_repl
 
@@ -237,7 +239,7 @@ def get_repo_lean_version(repo_path: Path) -> str:
 
 
 def prepare_and_process_lean_repo(repo_url: str, branch: str | None = None, 
-                  lean_data: Path | None = None, subdir: str | None = None):
+                  lean_data: Optional[Path] = None, subdir: str | None = None):
     """
     Comprehensive function that prepares a repository, builds a Lean project, 
     processes it to find sorries, and collects repository metadata.
@@ -245,18 +247,30 @@ def prepare_and_process_lean_repo(repo_url: str, branch: str | None = None,
     Args:
         repo_url: Git remote URL (HTTPS or SSH) of the repository to process
         branch: Optional branch to checkout (default: repository default branch)
-        lean_data: Path to the lean data directory (default: ./lean_data)
+        lean_data: Path to the lean data directory (default: create temporary directory)
         subdir: Optional subdirectory to restrict search to
         lean_version_tag: Optional Lean version tag to use for REPL
         
     Returns:
         dict: A dictionary containing repository metadata and sorries information
     """
-    # Set default lean_data directory if not provided
+    # Use a temporary directory by default if lean_data is not provided
     if lean_data is None:
-        lean_data = Path("lean_data")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            logger.info(f"Using temporary directory for lean data: {temp_dir}")
+            return _process_repo_with_lean_data(repo_url, branch, Path(temp_dir), subdir)
+    else:
+        # If lean_data is provided, make sure it exists
+        lean_data = Path(lean_data)
         lean_data.mkdir(exist_ok=True)
-    
+        logger.info(f"Using non-temporary directory for lean data: {lean_data}")
+        return _process_repo_with_lean_data(repo_url, branch, lean_data, subdir)
+
+def _process_repo_with_lean_data(repo_url: str, branch: str | None, 
+                               lean_data: Path, subdir: str | None = None):
+    """
+    Helper function that does the actual repository processing with a given lean_data directory.
+    """
     logger.info(f"Processing repository: {repo_url}")
     if branch:
         logger.info(f"Using branch: {branch}")
@@ -295,7 +309,7 @@ def prepare_and_process_lean_repo(repo_url: str, branch: str | None = None,
     return results
 
 
-def build_database(repo_list: list, lean_data: Path, output_path: str | Path):
+def build_database(repo_list: list, lean_data: Optional[Path], output_path: str | Path):
     """
     Build a SorryDatabase from multiple repositories.
     
@@ -310,10 +324,6 @@ def build_database(repo_list: list, lean_data: Path, output_path: str | Path):
     Returns:
         SorryDatabase: A database object containing all sorries from all repositories
     """
-    # Create lean data directory if it doesn't exist
-    lean_data_path = Path(lean_data)
-    lean_data_path.mkdir(exist_ok=True)
-    
     # Initialize empty list to store all sorries
     all_sorries = []
     
@@ -328,7 +338,7 @@ def build_database(repo_list: list, lean_data: Path, output_path: str | Path):
             repo_results = prepare_and_process_lean_repo(
                 repo_url=repo_url,
                 branch=branch,
-                lean_data=lean_data_path,
+                lean_data=lean_data,
                 subdir=subdir
             )
 

--- a/src/sorrydb/scripts/build_sorry_db.py
+++ b/src/sorrydb/scripts/build_sorry_db.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
+from typing import Optional
 
 from sorrydb.database.build_database import build_database
 
@@ -13,8 +14,8 @@ def main():
                        help='JSON file containing list of repositories to process')
     parser.add_argument('--output', type=str, default='sorry_database.json',
                        help='Output file path for the database (default: sorry_database.json)')
-    parser.add_argument('--lean-data-dir', type=str, default='lean_data',
-                       help='Directory for repository checkouts and Lean data (default: lean_data)')
+    parser.add_argument('--lean-data-dir', type=str, default="",
+                       help='Directory for repository checkouts and Lean data (default: create a temporary directory)')
     # Add simple logging options
     parser.add_argument('--log-level', type=str, default='INFO',
                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
@@ -36,8 +37,9 @@ def main():
     logger = logging.getLogger(__name__)
     
     # Create lean data directory
-    lean_data = Path(args.lean_data_dir)
-    lean_data.mkdir(exist_ok=True)
+    lean_data: Optional[Path] = Path(args.lean_data_dir) if args.lean_data_dir != '' else None
+    if lean_data:
+        lean_data.mkdir(exist_ok=True)
     
     with open(args.repos_file, 'r') as f:
         repos_data = json.load(f)

--- a/src/sorrydb/scripts/offline_sorries.py
+++ b/src/sorrydb/scripts/offline_sorries.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 import json
 import logging
+from typing import Optional
 
 from sorrydb.database.build_database import prepare_and_process_lean_repo
 
@@ -13,8 +14,8 @@ def main():
                        help='Git remote URL (HTTPS or SSH) of the repository to process')
     parser.add_argument('--branch', type=str,
                        help='Branch to process (default: repository default branch)')
-    parser.add_argument('--lean-data-dir', type=str, default='lean_data',
-                       help='Directory for repository checkouts (default: lean_data)')
+    parser.add_argument('--lean-data-dir', type=str, default="",
+                       help='Directory for repository checkouts and Lean data (default: create a temporary directory)')
     parser.add_argument('--dir', type=str,
                        help='Subdirectory to search for Lean files (default: entire repository)')
     # Add simple logging options
@@ -35,8 +36,10 @@ def main():
         log_kwargs['filename'] = args.log_file
     logging.basicConfig(**log_kwargs)
     
-    lean_data = Path(args.lean_data_dir)
-    lean_data.mkdir(exist_ok=True)
+    # Create lean data directory
+    lean_data: Optional[Path] = Path(args.lean_data_dir) if args.lean_data_dir != '' else None
+    if lean_data:
+        lean_data.mkdir(exist_ok=True)
     
     results = prepare_and_process_lean_repo(
         repo_url=args.repo_url,


### PR DESCRIPTION
By default `build_database` now uses a temporary directory. 

The `--repos-file` flag remains to specify a non-temporary file. I think this option is useful for speeding up development.