### PR TITLE
Use lake build output to filter files with sorries

### DIFF
--- a/src/sorrydb/crawler/git_ops.py
+++ b/src/sorrydb/crawler/git_ops.py
@@ -213,7 +213,7 @@ def leaf_commits(remote_url: str) -> list[dict]:
             - date: ISO formatted date of the commit
     """
     try:
-        logger.info(f"Getting leaf commits for {remote_url}")
+        logger.debug(f"Getting leaf commits for {remote_url}")
         
         # Create a temporary directory for cloning
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -273,7 +273,7 @@ def leaf_commits(remote_url: str) -> list[dict]:
             if len(commits) == 0:
                 logger.warning(f"No branches found for {remote_url}")
             else:
-                logger.info(f"Found {len(commits)} branches with commit dates in {remote_url}")
+                logger.debug(f"Found {len(commits)} branches with commit dates in {remote_url}")
             return commits
             
     except Exception as e:

--- a/src/sorrydb/crawler/git_ops.py
+++ b/src/sorrydb/crawler/git_ops.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import shutil
 from git import Repo
+from datetime import datetime, timezone
 from typing import Optional, Dict
 import tempfile
 import subprocess
@@ -247,14 +248,26 @@ def leaf_commits(remote_url: str) -> list[dict]:
                 # Format: "origin/branch sha date"
                 parts = line.split()
                 branch = parts[0].replace('origin/', '')
+                date_str = " ".join(parts[2:])
                 sha = parts[1]
-                # Join the remaining parts as the date (might contain spaces)
-                date = " ".join(parts[2:])
-                logger.debug(f"Parsed branch: {branch}, sha: {sha}, date: {date}")
+                # Join the remaining parts as the date, and parse it
+                try:
+                    date = datetime.fromisoformat(date_str)
+                    # Convert to UTC
+                    if date.tzinfo is not None:
+                        date = date.astimezone(timezone.utc)
+                    else:
+                        # If no timezone info, assume UTC
+                        date = date.replace(tzinfo=timezone.utc)
+                    date_iso = date.isoformat()
+                except ValueError:
+                    logger.warning(f"Failed to parse date: {date_str}")
+                    continue
+                logger.debug(f"Parsed branch: {branch}, sha: {sha}, date: {date_iso}")
                 commits.append({
                     'branch': branch,
                     'sha': sha,
-                    'date': date
+                    'date': date_iso
                 })
             
             if len(commits) == 0:

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -67,9 +67,8 @@ def build_lean_project(repo_path: Path) -> list[Path]:
                     line = line[9:]
                 file_path_str = line.split(":", 1)[0]
                 file_path = Path(file_path_str)
-                full_path = repo_path / file_path
-                
-                if full_path.exists():
+                full_path = repo_path / file_path                
+                if file_path not in sorry_files and full_path.exists():
                     logger.debug(f"Found sorry file: {file_path}")
                     sorry_files.append(file_path)
                 else:

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -26,19 +26,22 @@ def build_lean_project(repo_path: Path):
         return
     
     # Check if the project uses mathlib4
-    uses_mathlib4 = False
+    use_cache = False
     manifest_path = repo_path / "lake-manifest.json"
     if manifest_path.exists():
         try:
             manifest_content = manifest_path.read_text()
             if "https://github.com/leanprover-community/mathlib4" in manifest_content:
-                uses_mathlib4 = True
+                use_cache = True
                 logger.info("Project uses mathlib4, will get build cache")
+            elif "\"name\": \"mathlib\"" in manifest_content:
+                use_cache = True
+                logger.info("Mathlib4 branch, will get build cache")
         except Exception as e:
             logger.warning(f"Could not read lake-manifest.json: {e}")
     
     # Only get build cache if the project uses mathlib4
-    if uses_mathlib4:
+    if use_cache:
         logger.info("Getting build cache...")
         result = subprocess.run(["lake", "exe", "cache", "get"], cwd=repo_path)
         if result.returncode != 0:

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -478,7 +478,7 @@ def update_database(database_path: Path, lean_data: Optional[Path] = None):
                 logger.info(f"Added new commit {commit_entry['sha']} with {len(commit_entry['sorries'])} sorries")
                 
             except Exception as e:
-                logger.error(f"Error processing repository {remote_url}: {e}")
+                logger.warning(f"Error processing repository {remote_url}: {e}")
                 logger.exception(e)
                 # Continue with next repository
                 continue

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -421,12 +421,16 @@ def update_database(database_path: Path, lean_data: Optional[Path] = None):
         all_commits = leaf_commits(remote_url)
         
         # Filter commits after last visited date
-        last_visited = datetime.datetime.fromisoformat(repo["last_time_visited"])
+        last_visited_str = repo["last_time_visited"]
+        last_visited = datetime.datetime.fromisoformat(last_visited_str)
+        logger.debug(f"Last visited datestring: {last_visited_str}")
         filtered_commits = []
-        
+            
         for commit in all_commits:
             # Parse the commit date
-            commit_date = datetime.datetime.fromisoformat(commit["date"])
+            commit_date_str = commit["date"]
+            commit_date = datetime.datetime.fromisoformat(commit_date_str)
+            logger.debug(f"Commit datestring: {commit_date_str}")
             
             # Only include commits that are newer than the last visited date
             if commit_date > last_visited:
@@ -438,7 +442,7 @@ def update_database(database_path: Path, lean_data: Optional[Path] = None):
         logger.info(f"Filtered {len(all_commits)} commits to {len(filtered_commits)} new commits after {last_visited.isoformat()}")
         
         # Update the last_time_visited timestamp
-        current_time = datetime.datetime.now().isoformat()
+        current_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
         database["repos"][repo_index]["last_time_visited"] = current_time
         
         # Update the remote_heads_hash

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -216,6 +216,7 @@ def process_lean_repo(repo_path: Path, lean_data: Path, version_tag: str | None 
     if sorry_files:
         lean_files = sorry_files
     else:
+        logger.warning("No sorry files provided, processing lean files containing 'sorry' string")
         lean_files = [f for f in repo_path.rglob("*.lean") 
                       if ".lake" not in f.parts and should_process_file(f)]
     

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -68,11 +68,12 @@ def build_lean_project(repo_path: Path) -> list[Path]:
                 file_path_str = line.split(":", 1)[0]
                 file_path = Path(file_path_str)
                 full_path = repo_path / file_path                
-                if file_path not in sorry_files and full_path.exists():
-                    logger.debug(f"Found sorry file: {file_path}")
-                    sorry_files.append(file_path)
-                else:
-                    logger.warning(f"Could not find file: {full_path}")
+                if file_path not in sorry_files:
+                    if full_path.exists():
+                        logger.debug(f"Found sorry file: {file_path}")
+                        sorry_files.append(file_path)
+                    else:
+                        logger.warning(f"Could not find file: {full_path}")
     
     logger.info(f"Found {len(sorry_files)} files containing sorries from build output")
     

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -91,7 +91,7 @@ def should_process_file(lean_file: Path) -> bool:
     that don't need to be processed by REPL.
     """
     text = lean_file.read_text()
-    return any(term in text for term in ["sorry", "admit", "proof_wanted"])
+    return any(term in text for term in ["sorry",  "proof_wanted"])
 
 def process_lean_file(relative_path: Path, repo_path: Path, repl_binary: Path) -> list | None:
     """Process a Lean file to find sorries and their proof states.

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -210,17 +210,22 @@ def process_lean_repo(repo_path: Path, lean_data: Path, version_tag: str | None 
                 - endColumn: int, ending column number
             - blame: dict, git blame information for the sorry line
     """
-    repl_binary = setup_repl(lean_data, version_tag)
     
     # Build list of files to process
-    if sorry_files:
-        lean_files = sorry_files
-    else:
+    if sorry_files is None:
         logger.warning("No sorry files provided, processing lean files containing 'sorry' string")
         lean_files = [f for f in repo_path.rglob("*.lean") 
                       if ".lake" not in f.parts and should_process_file(f)]
-    
+    else:
+        lean_files = sorry_files
+
+    if len(lean_files) == 0:
+        logger.info("No files with potential sorries found, returning empty list")
+        return []
+
     logger.info(f"Found {len(lean_files)} files containing potential sorries")
+
+    repl_binary = setup_repl(lean_data, version_tag)
     
     results = []
     for rel_path in lean_files:

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -91,7 +91,7 @@ def should_process_file(lean_file: Path) -> bool:
     that don't need to be processed by REPL.
     """
     text = lean_file.read_text()
-    return any(term in text for term in ["sorry",  "proof_wanted"])
+    return any(term in text for term in ["sorry"])
 
 def process_lean_file(relative_path: Path, repo_path: Path, repl_binary: Path) -> list | None:
     """Process a Lean file to find sorries and their proof states.

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -53,16 +53,16 @@ def build_lean_project(repo_path: Path) -> list[Path] | None:
     
     logger.info("Building project...")
     try:
-        # Run lake build with a 1-minute timeout
+        # Run lake build with a 5-minute timeout
         result = subprocess.run(
             ["lake", "build"], 
             cwd=repo_path, 
             capture_output=True, 
             text=True, 
-            timeout=60
+            timeout=300
         )
     except subprocess.TimeoutExpired:
-        logger.warning("lake build timed out after 1 minute")
+        logger.warning("lake build timed out after 5 minutes")
         return None
 
     # Check for build failure


### PR DESCRIPTION
This PR attempts to use the output of 'lake build' to filter out sorries. This should drastically cut down the number of files to visit in mathlib branches, and may be a better implementation in general as well.

New issue: the CI on mathlib4 builds cached oleans also for branches. But if a modified file in a branch already has been built and cached, then 'lake build' will not report the sorries....