### PR TITLE
Foundation for database statistics

### DIFF
--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -417,7 +417,7 @@ def process_new_commits(database, repo_index, commits, remote_url, lean_data):
     return new_sorries_stats
 
 
-def update_database(database_path: Path, write_database_path: Optional[Path] = None, lean_data: Optional[Path] = None) -> dict:
+def update_database(database_path: Path, write_database_path: Optional[Path] = None, lean_data: Optional[Path] = None, stats_file: Optional[Path] = None) -> dict:
     """
     Update a SorryDatabase by checking for changes in repositories and processing new commits.
     
@@ -425,6 +425,9 @@ def update_database(database_path: Path, write_database_path: Optional[Path] = N
         database_path: Path to the database JSON file
         write_database_path: Path to write the databse JSON file (default: database_path)
         lean_data: Path to the lean data directory (default: create temporary directory)
+        stats_file: file to write database stats (default: don't write statistics to file)
+    Returns:
+        update_database_stats: statistics on the sorries that were added to the database
     """
 
     if not write_database_path:
@@ -499,5 +502,12 @@ def update_database(database_path: Path, write_database_path: Optional[Path] = N
     with open(write_database_path, 'w') as f:
         json.dump(database, f, indent=2)
     logger.info("Database update completed successfully")
+
+    # Write database statistics if file is provided
+    if stats_file:
+        stats_path = Path(stats_file)
+        with open(stats_path, 'w') as f:
+            json.dump(update_database_stats, f, indent=2)
+        logger.info(f"Update statistics written to {stats_path}")
 
     return update_database_stats

--- a/src/sorrydb/scripts/update_db.py
+++ b/src/sorrydb/scripts/update_db.py
@@ -33,6 +33,12 @@ def main():
     parser.add_argument(
         "--log-file", type=str, help="Log file path (default: output to stdout)"
     )
+    parser.add_argument(
+        "--stats-file",
+        type=str,
+        default=None,
+        help="Path to write update statistics (JSON format)",
+    )
 
     args = parser.parse_args()
 
@@ -53,7 +59,7 @@ def main():
 
     # Update the database
     try:
-        update_database(database_path=database_path, lean_data=lean_data)
+        update_database(database_path=database_path, lean_data=lean_data, stats_file=args.stats_file)
         return 0
 
     except Exception as e:

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -1,7 +1,9 @@
 import json
 
-from sorrydb.database.build_database import (prepare_and_process_lean_repo,
-                                             update_database)
+from sorrydb.database.build_database import (
+    prepare_and_process_lean_repo,
+    update_database,
+)
 
 
 def test_prepare_and_process_lean_repo_with_mutiple_lean_versions():
@@ -55,7 +57,14 @@ def test_update_database(
     tmp_write_db = tmp_path / "updated_sorry_database.json"
 
     # Update database
-    update_database(init_db_single_test_repo_path, tmp_write_db)
+    update_stats = update_database(init_db_single_test_repo_path, tmp_write_db)
+
+    assert update_stats == {
+        "https://github.com/austinletson/sorryClientTestRepo": {
+            "78202012bfe87f99660ba2fe5973eb1a8110ab64": {"count": 4},
+            "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {"count": 5},
+        }
+    }
 
     assert tmp_write_db.exists(), "The updated database file was not created"
 
@@ -72,6 +81,6 @@ def test_update_database(
     normalized_expected = normalize_sorrydb_for_comparison(expected_content)
 
     # Compare the normalized JSONs
-    assert (
-        normalized_tmp == normalized_expected
-    ), "The sorries data doesn't match the expected content"
+    assert normalized_tmp == normalized_expected, (
+        "The sorries data doesn't match the expected content"
+    )


### PR DESCRIPTION
This provides a foundation for providing database statistics as described in #60.

Add a `--stats-file` argument to `update_db` to save database stats to a file.

Add logic which aggregates stats while updating the database by calling the `compute_new_sorries_stats()` function when new sorries are added to the database.

In order to add all the statistics outlined in #60 we will need to query the database. I think it is best to wait to implement this functionality until we have solidified the database design (#17) and implemented the new format.

Note, this is stacked on #62