### PR TITLE
fix: remove SSA repo

### DIFF
--- a/repo_lists/active_repos_without_mathlib.json
+++ b/repo_lists/active_repos_without_mathlib.json
@@ -56,9 +56,6 @@
             "remote": "https://github.com/YaelDillies/LeanCamCombi"
         },
         {
-            "remote": "https://github.com/opencompl/SSA"
-        },
-        {
             "remote": "https://github.com/YaelDillies/LeanAPAP"
         },
         {


### PR DESCRIPTION
Currently the [opencompl/mlir](https://github.com/opencompl/lean-mlir) (AKA opencompl/SSA. It must have been renamed.) repo takes a very long time to build compared to other repos and lake build eventually fails. I don't understand why exactly. It usually takes 2.5 hours to process this repo alone.

@LennyTaelman do you object to removing it from the active repos list for now? If lake build is always failing it isn't adding anything currently anyway. We can always add it back after we get the database up and running.