### PR TITLE
fix: use top-level sorrydb python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,17 +20,14 @@ ruff = "^0.11.1"
 
 [tool.poetry]
 packages = [
-	{ include = "database", from = "sorrydb" },
-	{ include = "clients", from = "sorrydb" },
-	{ include = "utils", from = "sorrydb" },
-	{ include = "cli", from = "sorrydb" }
+	{ include = "sorrydb"},
 ]
 
 
 [tool.poetry.scripts]
-init_db = "cli.init_db:main"
-update_db = "cli.update_db:main"
-run_rfl_client = "cli.run_rfl_client:main"
+init_db = "sorrydb.cli.init_db:main"
+update_db = "sorrydb.cli.update_db:main"
+run_rfl_client = "sorrydb.cli.run_rfl_client:main"
 
 
 [build-system]

--- a/sorrydb/cli/init_db.py
+++ b/sorrydb/cli/init_db.py
@@ -6,7 +6,7 @@ import json
 import logging
 from pathlib import Path
 
-from database.build_database import init_database
+from sorrydb.database.build_database import init_database
 
 
 def main():

--- a/sorrydb/cli/run_rfl_client.py
+++ b/sorrydb/cli/run_rfl_client.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from pathlib import Path
 
-from clients.rfl_client.rfl_client import process_sorry_json
+from sorrydb.clients.rfl_client.rfl_client import process_sorry_json
 
 
 def main():

--- a/sorrydb/cli/update_db.py
+++ b/sorrydb/cli/update_db.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 from pathlib import Path
 
-from database.build_database import update_database
+from sorrydb.database.build_database import update_database
 
 
 def main():

--- a/sorrydb/clients/rfl_client/rfl_client.py
+++ b/sorrydb/clients/rfl_client/rfl_client.py
@@ -6,10 +6,10 @@ import tempfile
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-from database.process_sorries import build_lean_project
-from utils.git_ops import prepare_repository
-from utils.lean_repo import build_lean_project
-from utils.repl_ops import LeanRepl, setup_repl
+from sorrydb.database.process_sorries import build_lean_project
+from sorrydb.utils.git_ops import prepare_repository
+from sorrydb.utils.lean_repo import build_lean_project
+from sorrydb.utils.repl_ops import LeanRepl, setup_repl
 
 # Create a module-level logger
 logger = logging.getLogger(__name__)

--- a/sorrydb/database/build_database.py
+++ b/sorrydb/database/build_database.py
@@ -8,8 +8,8 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
-from database.process_sorries import prepare_and_process_lean_repo
-from utils.git_ops import leaf_commits, remote_heads_hash
+from sorrydb.database.process_sorries import prepare_and_process_lean_repo
+from sorrydb.utils.git_ops import leaf_commits, remote_heads_hash
 
 # Create a module-level logger
 logger = logging.getLogger(__name__)

--- a/sorrydb/database/process_sorries.py
+++ b/sorrydb/database/process_sorries.py
@@ -3,13 +3,13 @@ import logging
 import subprocess
 from pathlib import Path
 
-from utils.git_ops import (
+from sorrydb.utils.git_ops import (
     get_git_blame_info,
     get_repo_metadata,
     prepare_repository,
 )
-from utils.lean_repo import build_lean_project
-from utils.repl_ops import LeanRepl, setup_repl
+from sorrydb.utils.lean_repo import build_lean_project
+from sorrydb.utils.repl_ops import LeanRepl, setup_repl
 
 # Create a module-level logger
 logger = logging.getLogger(__name__)

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -1,6 +1,6 @@
 import json
 
-from database.build_database import (
+from sorrydb.database.build_database import (
     prepare_and_process_lean_repo,
     update_database,
 )

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest.mock as mock
 
-from utils.git_ops import leaf_commits, remote_heads, remote_heads_hash
+from sorrydb.utils.git_ops import leaf_commits, remote_heads, remote_heads_hash
 
 
 def test_remote_heads():
@@ -23,7 +23,7 @@ def test_remote_heads():
 def test_remote_heads_hash_different():
     """Test that different sets of branch heads produce different hash values."""
     # Mock the remote_heads function to return controlled test data
-    with mock.patch("sorrydb.crawler.git_ops.remote_heads") as mock_remote_heads:
+    with mock.patch("sorrydb.utils.git_ops.remote_heads") as mock_remote_heads:
         # First set of branch heads
         mock_remote_heads.return_value = [
             {"branch": "main", "sha": "abc123"},
@@ -41,7 +41,7 @@ def test_remote_heads_hash_different():
         # Verify that different branch heads produce different hashes
         assert hash1 != hash2, "Modified branch should produce different hashes"
 
-    with mock.patch("sorrydb.crawler.git_ops.remote_heads") as mock_remote_heads:
+    with mock.patch("sorrydb.utils.git_ops.remote_heads") as mock_remote_heads:
         # First set of branch heads
         mock_remote_heads.return_value = [
             {"branch": "main", "sha": "abc123"},


### PR DESCRIPTION
Poetry wasn't able to find the sub-directory packages.

This also avoids namespace collisions with other packages.