### PR TITLE
feat: move database stats processing to `JsonDatabase`

### DIFF
--- a/sorrydb/database/sorry_database.py
+++ b/sorrydb/database/sorry_database.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import defaultdict
 from dataclasses import asdict
 from pathlib import Path
 
@@ -11,6 +12,9 @@ logger = logging.getLogger(__name__)
 class JsonDatabase:
     def __init__(self):
         self.data = None
+        self.update_stats = defaultdict(
+            lambda: defaultdict(lambda: {"count": 0, "count_new": 0})
+        )
 
     def load_database(self, database_path):
         """
@@ -36,9 +40,25 @@ class JsonDatabase:
     def get_all_repos(self):
         return self.data["repos"]
 
-    def add_sorries(self, sorries: list[Sorry]):
-        sorries_dict = map(asdict, sorries)
-        self.data["sorries"].extend(sorries_dict)
+    def add_sorry(self, sorry: Sorry):
+        sorry_dict = asdict(sorry)
+        self.data["sorries"].append(sorry_dict)
+
+        repo_url = sorry.repo.remote
+        commit_sha = sorry.repo.commit
+
+        is_new_goal = False
+        current_goal = sorry.debug_info.goal if sorry.debug_info else None
+        if current_goal:
+            is_new_goal = all(
+                existing_sorry.get("debug_info", {}).get("goal") != current_goal
+                for existing_sorry in self.data["sorries"][:-1]
+            )
+
+        repo_stats = self.update_stats[repo_url][commit_sha]
+        repo_stats["count"] += 1
+        if is_new_goal:
+            repo_stats["count_new"] += 1
 
     def write_database(self, write_database_path: Path):
         logger.info(f"Writing updated database to {write_database_path}")
@@ -50,3 +70,13 @@ class JsonDatabase:
                 default=Sorry.default_json_serialization,
             )
         logger.info("Database update completed successfully")
+
+    def write_stats(self, write_stats_path: Path):
+        logger.info(f"Writing database update stats to {write_stats_path}")
+        with open(write_stats_path, "w") as f:
+            json.dump(
+                self.update_stats,
+                f,
+                indent=2,
+            )
+        logger.info("Database stats written successfully")

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -77,8 +77,8 @@ def test_update_database_single_repo(
 
     assert update_stats == {
         "https://github.com/austinletson/sorryClientTestRepo": {
-            "78202012bfe87f99660ba2fe5973eb1a8110ab64": {"count": 3},
-            "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {"count": 4},
+            "78202012bfe87f99660ba2fe5973eb1a8110ab64": {"count": 3, "count_new": 2},
+            "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {"count": 4, "count_new": 1},
         }
     }
 


### PR DESCRIPTION
Move database stats to `JsonDatabase` to avoid returning stats in functions in `build_database.py`

Add "count_new" to database stats which counts the number of new proofs in each leaf commit.


Related to #60 