### PR TITLE
More database stats

### DIFF
--- a/sorrydb/database/sorry_database.py
+++ b/sorrydb/database/sorry_database.py
@@ -2,6 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from dataclasses import asdict
+from datetime import datetime
 from pathlib import Path
 
 from sorrydb.database.sorry import Sorry
@@ -13,8 +14,50 @@ class JsonDatabase:
     def __init__(self):
         self.data = None
         self.update_stats = defaultdict(
-            lambda: defaultdict(lambda: {"count": 0, "count_new": 0})
+            lambda: {
+                "counts": defaultdict(lambda: {"count": 0, "count_new": 0}),
+                "new_leaf_commit": None,
+                "start_processing_time": None,
+                "end_processing_time": None,
+                "total_processing_time": None,
+                "lake_timeout": None,
+            }
         )
+
+    def set_new_leaf_commit(self, repo_url, new_leaf_commit):
+        self.update_stats[repo_url]["new_leaf_commit"] = new_leaf_commit
+
+    def set_start_processing_time(self, repo_url, start_processing_time):
+        self.update_stats[repo_url]["start_processing_time"] = start_processing_time
+
+    def set_end_processing_time(self, repo_url, end_processing_time):
+        self.update_stats[repo_url]["end_processing_time"] = end_processing_time
+        self._update_total_processing_time(repo_url)
+
+    def _update_total_processing_time(self, repo_url):
+        start_time = self.update_stats[repo_url]["start_processing_time"]
+        end_time = self.update_stats[repo_url]["end_processing_time"]
+
+        if start_time and end_time:
+            start_dt = datetime.fromisoformat(start_time)
+            end_dt = datetime.fromisoformat(end_time)
+            total_seconds = (end_dt - start_dt).total_seconds()
+
+            # Format the time in a human-readable format
+            hours, remainder = divmod(int(total_seconds), 3600)
+            minutes, seconds = divmod(remainder, 60)
+
+            if hours > 0:
+                human_readable = f"{hours}h {minutes}m {seconds}s"
+            elif minutes > 0:
+                human_readable = f"{minutes}m {seconds}s"
+            else:
+                human_readable = f"{seconds}s"
+
+            self.update_stats[repo_url]["total_processing_time"] = human_readable
+
+    def set_lake_timeout(self, repo_url, lake_timeout):
+        self.update_stats[repo_url]["lake_timeout"] = lake_timeout
 
     def load_database(self, database_path):
         """
@@ -55,7 +98,7 @@ class JsonDatabase:
                 for existing_sorry in self.data["sorries"][:-1]
             )
 
-        repo_stats = self.update_stats[repo_url][commit_sha]
+        repo_stats = self.update_stats[repo_url]["counts"][commit_sha]
         repo_stats["count"] += 1
         if is_new_goal:
             repo_stats["count_new"] += 1

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -135,16 +135,46 @@ def test_update_database_multiple_repo(
 
     update_stats = update_database(init_db_mock_multiple_repos_path, tmp_write_db)
 
-    assert update_stats == {
+    normalized_stats = normalize_update_stats_for_comparison(update_stats)
+
+    expected_stats = {
         "https://github.com/austinletson/sorryClientTestRepo": {
-            "78202012bfe87f99660ba2fe5973eb1a8110ab64": {"count": 3, "count_new": 2},
-            "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {"count": 4, "count_new": 1},
+            "counts": {
+                "78202012bfe87f99660ba2fe5973eb1a8110ab64": {
+                    "count": 3,
+                    "count_new": 2,
+                },
+                "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {
+                    "count": 4,
+                    "count_new": 1,
+                },
+            },
+            "new_leaf_commit": True,
+            "start_processing_time": "NORMALIZED_TIMESTAMP",
+            "end_processing_time": "NORMALIZED_TIMESTAMP",
+            "total_processing_time": "NORMALIZED_TIMESTAMP",
+            "lake_timeout": None,
         },
         "https://github.com/austinletson/sorryClientTestRepoMath": {
-            "e853cb7ab1cdb382ea12b3f11bcbe6bbfeb32d47": {"count": 1, "count_new": 1},
-            "c1c539f7432bafccd8eaf55f363eaad4e0b92374": {"count": 2, "count_new": 1},
+            "counts": {
+                "e853cb7ab1cdb382ea12b3f11bcbe6bbfeb32d47": {
+                    "count": 1,
+                    "count_new": 1,
+                },
+                "c1c539f7432bafccd8eaf55f363eaad4e0b92374": {
+                    "count": 2,
+                    "count_new": 1,
+                },
+            },
+            "new_leaf_commit": True,
+            "start_processing_time": "NORMALIZED_TIMESTAMP",
+            "end_processing_time": "NORMALIZED_TIMESTAMP",
+            "total_processing_time": "NORMALIZED_TIMESTAMP",
+            "lake_timeout": None,
         },
     }
+
+    assert normalized_stats == expected_stats
 
     assert tmp_write_db.exists(), "The updated database file was not created"
 

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -66,6 +66,15 @@ def normalize_sorrydb_for_comparison(data):
     return data
 
 
+def normalize_update_stats_for_comparison(update_stats):
+    """Normalize timestamps in update_stats dictionary in place."""
+    for repo_url, repo_data in update_stats.items():
+        repo_data["start_processing_time"] = "NORMALIZED_TIMESTAMP"
+        repo_data["end_processing_time"] = "NORMALIZED_TIMESTAMP"
+        repo_data["total_processing_time"] = "NORMALIZED_TIMESTAMP"
+    return update_stats
+
+
 def test_update_database_single_repo(
     init_db_mock_single_path, update_db_single_test_repo_path, tmp_path
 ):
@@ -75,12 +84,29 @@ def test_update_database_single_repo(
 
     update_stats = update_database(init_db_mock_single_path, tmp_write_db)
 
-    assert update_stats == {
+    normalized_stats = normalize_update_stats_for_comparison(update_stats)
+
+    expected_stats = {
         "https://github.com/austinletson/sorryClientTestRepo": {
-            "78202012bfe87f99660ba2fe5973eb1a8110ab64": {"count": 3, "count_new": 2},
-            "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {"count": 4, "count_new": 1},
+            "counts": {
+                "78202012bfe87f99660ba2fe5973eb1a8110ab64": {
+                    "count": 3,
+                    "count_new": 2,
+                },
+                "f8632a130a6539d9f546a4ef7b412bc3d86c0f63": {
+                    "count": 4,
+                    "count_new": 1,
+                },
+            },
+            "new_leaf_commit": True,
+            "start_processing_time": "NORMALIZED_TIMESTAMP",
+            "end_processing_time": "NORMALIZED_TIMESTAMP",
+            "total_processing_time": "NORMALIZED_TIMESTAMP",
+            "lake_timeout": None,
         }
     }
+
+    assert normalized_stats == expected_stats
 
     assert tmp_write_db.exists(), "The updated database file was not created"
 


### PR DESCRIPTION
Add `new_leaf_commit`, `start_processing_time`, `end_processing_time`, `total_processing_time`, and `lake_timeout` to database stats at the repo level.

Stacked on #88 