### PR TITLE
Add repository owners and contributors info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ This is the snapshot evaluated in the paper "SorryDB: Can AI Provers Complete Re
 - The 1000-sorry evaluation split used in the paper: [data/SorryDB_2601/SorryDB_2601_1000_evaluation_split.json](data/SorryDB_2601/SorryDB_2601_1000_evaluation_split.json)
 
 
+## Information for repository owners and contributors
+
+We intend to track all sorries in Lean 4 repositories listed by
+[Reservoir](https://reservoir.lean-lang.org/packages). If you want your
+repository to be indexed, make sure it satisfies the [inclusion
+criteria](https://reservoir.lean-lang.org/inclusion-criteria). In particular, it
+must have an open source
+license.
+
+Even if your repository is listed on Reservoir, you can opt out from having it
+indexed. We can also exclude sorries based on authorship (determined via [git
+blame](https://git-scm.com/docs/git-blame)). In both cases, please contact
+[Austin Letson](mailto:waustinletson@gmail.com).
+
+
 ## The sorry-proving strategies
 
 We treat each entry of the database as a theorem-proving challenge, where the


### PR DESCRIPTION
## Summary
- Adds the **Information for repository owners and contributors** section to the README, mirroring the [same section](https://github.com/SorryDB/sorrydb-data#information-for-repository-owners-and-contributors) from the `sorrydb-data` repo.
- Sets the contact to **Austin Letson** (`waustinletson@gmail.com`) instead of the original contact.

The section is placed right after the dataset section, since it concerns repository indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)